### PR TITLE
ALP-69: Configure github actions to run unit tests

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -1,0 +1,55 @@
+name: Run Catch2 unit tests
+define: $runner_version ubuntu-latest
+
+on:
+  pull_request:
+    types:
+      - closed
+  pull_request_review:
+    types: [submitted]
+  schedule:
+    - cron: '0 1 * * 1'
+
+jobs:
+
+  get-catch:
+    runs-on: *runner_version
+    steps:
+      - name: clone catch2 repo
+        run: git clone https://github.com/catchorg/Catch2.git && cd Catch2
+      - name: configure build
+        run: cmake -B build -S .
+      - name: build
+        run: cmake --build build -j ${nproc-2}
+
+  build:
+    needs: get-catch
+    runs-on: *runner_version
+    steps:
+      - uses: actions/checkout@v3
+      - name: set up packages
+        run: xargs sudo apt -y install < packages.txt
+      - name: configure
+        run: cmake -B build -S . -DBUILD_TESTS=ON
+      - name: build
+        run: cmake --build build -j ${nproc-2}
+
+  approved:
+    if: github.event.review.state == 'APPROVED'
+    needs: build
+    runs-on: *runner_version
+    steps:
+      - run: cd build/ && ctest
+
+  pr-merged:
+    if: github.event.pull_request.merged == true
+    needs: build
+    runs-on: *runner_version
+    steps:
+      - run: cd build/ && ctest
+
+  scheduled_test:
+    needs: build
+    runs-on: *runner_version
+    steps:
+      - run: cd build/ && ctest

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build*
 compile_commands.json
 .cache
 docs/
+Testing/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ if(BUILD_TESTS)
     find_package(Catch2 3 REQUIRED)
     include(CTest)
     include(Catch)
+    enable_testing()
 endif()
 
 # source configuration

--- a/package_list.txt
+++ b/package_list.txt
@@ -1,0 +1,2 @@
+libeigen3-dev
+cmake


### PR DESCRIPTION
Add github actions config to run units tests when:

1. PR is approved
2. `dev` receives merge from a PR
3. Every Monday night (before Tuesday meeting) at 8pm eastern
