### PR TITLE
Wwu/alp 62 implement landmark ekf

### DIFF
--- a/include/EKF.h
+++ b/include/EKF.h
@@ -1,0 +1,77 @@
+/**
+ * @file EKF.h
+ * @brief Defines the EKF class
+*/
+
+#pragma once
+
+#include "core-structs.h"
+#include "math-util.h"
+#include "robot-manager.h"
+#include "Eigen/Dense"
+#include <memory.h>
+
+/**
+ * @brief: Abstract EKF class that offers two core EKF functions
+*/
+class EKFBase {
+
+public:
+
+    /**
+     * @brief updates internal state and covariance based on motion model
+     * @details this function calculates the internal beliefs of the state and covariance
+     */
+    virtual void predict() = 0;
+
+    /**
+     * @brief corrects internal state and covariane based on measurement
+     */
+    virtual void update() = 0;
+
+};
+
+class LandMarkEKF: public EKFBase {
+
+public:
+
+    /**
+     * @brief calculate measurement's likelihood of correspondence to the landmark
+     * @details this function utilizes Maximum Likelihood Estimation (MLE) and is
+     * used to solve the data association problem
+     */
+    virtual float calcCPD() = 0;
+
+};
+
+class LMEKF2D: public LandMarkEKF{
+
+private:
+
+    Eigen::Matrix2f m_mu;
+
+    Eigen::Matrix2f m_sigma;
+
+    std::shared_ptr<RobotManager> m_robot;
+
+    Eigen::Matrix2f predictJacobian() const;
+
+    Eigen::Matrix2f measJacobian() const;
+
+    float calcKalmanGain() const;
+
+
+public:
+
+    LMEKF2D();
+
+    ~LMEKF2D();
+
+    void predict() override;
+
+    void update() override;
+
+    float calcCPD() override;
+
+};
+// candidate functions:

--- a/include/core-structs.h
+++ b/include/core-structs.h
@@ -6,11 +6,18 @@
 #pragma once
 
 #include <optional>
+#include <Eigen/Dense>
 
 /** A point (position only) in the 2D plane. */
 struct Point2D {
    float x;           // x-coordinate (scaled in meters)
    float y;           // y-coordinate (scaled in meters)
+
+   struct Point2D& operator+=(const Eigen::Vector2f& rhs) {
+      x += rhs[0];
+      y += rhs[1];
+      return *this;
+   }
 };
 
 /** A pose (position and orientation) in the 2D plane. */
@@ -18,6 +25,7 @@ struct Pose2D {
    float x;           // x-coordinate (scaled in meters)
    float y;           // y-coordinate (scaled in meters)
    float theta_rad;   // heading (radians) wrapped into [-pi, pi]
+
 };
 
 /**
@@ -41,4 +49,15 @@ struct Observation2D {
     *    Populating/clearing this field may be more trouble than it's worth...
     */
    std::optional<int> landmarkID;
+
+   /**
+    * @brief overloaded difference operator for residual calculation
+    * @return an eigen column vector representing the residual
+    */
+   Eigen::Vector2f operator-(const struct Observation2D& rhs) const {
+      float range_diff = this->range_m - rhs.range_m;
+      float bearing_diff = this->bearing_rad - rhs.bearing_rad;
+
+      return Eigen::Vector2f(range_diff, bearing_diff);
+   }
 };

--- a/include/math-util.h
+++ b/include/math-util.h
@@ -26,7 +26,7 @@ namespace MathUtil {
  * @param[in]    aWorld_quant  2D quantity in world frame
  * @param[in]    aTheta_rad    Robot heading angle in randians
  *
- * @returns quantity in robot frame
+ * @return quantity in robot frame
  */
 std::pair<float, float> worldToBody2D( const std::pair<float, float>& aWorld_quant,
                                        const float aTheta_rad);
@@ -39,7 +39,7 @@ std::pair<float, float> worldToBody2D( const std::pair<float, float>& aWorld_qua
  * @param[in]    aBody_pose   2D quantity in robot frame
  * @param[in]    aTheta_rad    Robot heading angle in randians
  *
- * @returns quantity in world frame
+ * @return quantity in world frame
  */
 std::pair<float, float> bodyToWorld2D(const std::pair<float, float>& aBody_quant,
                                       const float aTheta_rad);
@@ -58,7 +58,7 @@ std::pair<float, float> bodyToWorld2D(const std::pair<float, float>& aBody_quant
  * @param[in]     aMean       Mean of the sampled Normal distribution
  * @param[in]     aVariance   Variance of the sampled Normal distribution
  *
- * @returns Random value, distributed according to the defined Gaussian
+ * @return Random value, distributed according to the defined Gaussian
  */
 float sampleNormal( const float aMean, const float aVariance );
 

--- a/include/robot-manager.h
+++ b/include/robot-manager.h
@@ -9,7 +9,7 @@
 
 class RobotManager {
 public:
-    virtual float sampleIMU() = 0;
-    virtual struct Observation2D sampleLandMark() = 0;
-    virtual struct VelocityCommand2D sampleControl() = 0;
+    virtual void sampleIMU() = 0;
+    virtual void sampleLandMark() = 0;
+    virtual void sampleControl() = 0;
 };

--- a/include/robot-manager.h
+++ b/include/robot-manager.h
@@ -1,0 +1,15 @@
+/**
+ * @file robot-manager.h
+ * @brief Defines RobotManager and its derived classes for robot-specific code */
+
+#pragma once
+
+#include "core-structs.h"
+#include "math-util.h"
+
+class RobotManager {
+public:
+    virtual float sampleIMU() = 0;
+    virtual struct Observation2D sampleLandMark() = 0;
+    virtual struct VelocityCommand2D sampleControl() = 0;
+};

--- a/include/robot-manager.h
+++ b/include/robot-manager.h
@@ -1,15 +1,67 @@
 /**
  * @file robot-manager.h
- * @brief Defines RobotManager and its derived classes for robot-specific code */
+ * @brief Defines RobotManager and its derived classes for robot-specific code
+ */
 
 #pragma once
 
 #include "core-structs.h"
 #include "math-util.h"
+#include "Eigen/Dense"
+#include <iostream>
 
 class RobotManager {
 public:
     virtual void sampleIMU() = 0;
     virtual void sampleLandMark() = 0;
     virtual void sampleControl() = 0;
+};
+
+class RobotManager2D : public RobotManager {
+
+protected:
+    struct Pose2D m_curr_pose;
+    struct VelocityCommand2D m_curr_command;
+    const Eigen::Matrix2f m_meas_noise;
+    struct Observation2D m_curr_obs;
+
+    RobotManager2D(struct Pose2D init_pose,
+                   struct VelocityCommand2D init_cmd,
+                   Eigen::Matrix2f meas_noise) : m_curr_pose(init_pose),
+        m_curr_command(init_cmd), m_meas_noise(meas_noise){
+        m_curr_obs = { .range_m = 0, .bearing_rad = 0 };
+    }
+    RobotManager2D() {
+        m_curr_pose = {.x = 0, .y = 0, .theta_rad = 0};
+        m_curr_command = {.vx_mps = 0, .wz_radps = 0};
+    }
+    virtual ~RobotManager2D() {};
+
+public:
+    virtual void motionUpdate() = 0;
+    virtual struct Observation2D predictMeas() = 0;
+    virtual struct Observation2D getCurrObs() const = 0;
+    virtual Eigen::Matrix2f measJacobian(const struct Point2D mu_prev) const = 0;
+    virtual Eigen::Matrix2f getMeasNoise() const = 0;
+};
+
+class Create3Manager final : public RobotManager2D {
+
+public:
+    Create3Manager();
+    Create3Manager(struct Pose2D init_pose,
+                   struct VelocityCommand2D init_cmd,
+                   Eigen::Matrix2f meas_noise): RobotManager2D(init_pose, init_cmd, meas_noise) {}
+    ~Create3Manager() {};
+
+
+    void sampleIMU() override;
+    void sampleLandMark() override;
+    void sampleControl() override;
+    void motionUpdate() override;
+    struct Observation2D getCurrObs() const override;
+    struct Observation2D predictMeas() override;
+    Eigen::Matrix2f measJacobian(const struct Point2D mu_prev) const override;
+    Eigen::Matrix2f getMeasNoise() const override;
+
 };

--- a/src/FastSLAM/CMakeLists.txt
+++ b/src/FastSLAM/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_library(FastSLAMLib
    math-util.cpp
+   EKF.cpp
+   robot-manager.cpp
 )
 
 target_include_directories(FastSLAMLib PUBLIC
@@ -16,6 +18,16 @@ if(BUILD_TESTS)
                         FastSLAMLib)
   catch_discover_tests(test_MathUtil)
   target_include_directories(test_MathUtil PUBLIC
+    "${PROJECT_BINARY_DIR}"
+    "${PROJECT_SOURCE_DIR}/include"
+  )
+
+  add_executable(test_EKF EKF_test.cpp)
+  target_link_libraries(test_EKF
+                        PRIVATE Catch2::Catch2WithMain
+                        FastSLAMLib)
+  catch_discover_tests(test_EKF)
+  target_include_directories(test_EKF PUBLIC
     "${PROJECT_BINARY_DIR}"
     "${PROJECT_SOURCE_DIR}/include"
   )

--- a/src/FastSLAM/EKF.cpp
+++ b/src/FastSLAM/EKF.cpp
@@ -1,0 +1,85 @@
+/**
+ * @file EKF.cpp
+ * @brief Implements the EKF derived classes
+ */
+
+#include "EKF.h"
+
+
+LMEKF2D::LMEKF2D() {
+
+   m_mu = { .x = 0, .y = 0 };
+
+   m_sigma = Eigen::Matrix2f::Zero();
+
+   m_robot = nullptr;
+
+}
+
+LMEKF2D::LMEKF2D(struct Point2D init_obs, Eigen::Matrix2f init_cov,
+                 std::shared_ptr<RobotManager2D> robot_ptr) : m_mu(init_obs),
+   m_sigma(init_cov),
+   m_robot(robot_ptr) {
+}
+
+LMEKF2D::~LMEKF2D() {
+   m_robot.reset();
+}
+
+Eigen::Matrix2f LMEKF2D::measJacobian() const {
+    if (m_robot == nullptr) {
+        return Eigen::Matrix2f::Zero();
+    }
+    return m_robot->measJacobian(m_mu); // make sure this is called before update()
+}
+
+void LMEKF2D::calcMeasCov() {
+    Eigen::Matrix2f G_n = this->measJacobian();
+    m_meas_cov = G_n.transpose() * m_sigma * G_n + m_robot->getMeasNoise();
+}
+
+Eigen::Matrix2f LMEKF2D::calcKalmanGain() const {
+    if (m_robot == nullptr || m_meas_cov.determinant() == 0) {
+        return Eigen::Matrix2f::Zero();
+    }
+    return m_sigma * this->measJacobian() * (m_meas_cov.inverse());
+}
+
+KF_RET LMEKF2D::update() {
+    if (m_robot == nullptr) {
+        return KF_RET::EMPTY_ROBOT_MANAGER;
+    }
+
+    if (m_meas_cov.determinant() == 0) {
+        return KF_RET::MATRIX_INVERSION_ERROR;
+    } else {
+        Eigen::Matrix2f K = this->calcKalmanGain();
+        Eigen::Matrix2f G_n = this->measJacobian();
+
+        m_mu += K * ( m_robot->getCurrObs() - m_robot->predictMeas() );
+        m_sigma = ( Eigen::Matrix2f::Identity() - K * G_n ) * m_sigma;
+    }
+
+    return KF_RET::SUCCESS;
+}
+
+float LMEKF2D::calcCPD() {
+    if (m_robot == nullptr) {
+        return -1.0f;
+    }
+
+    this->calcMeasCov();
+    if (m_meas_cov.determinant() == 0) {
+        return -1.0f;
+    }
+
+    Eigen::Vector2f residue = m_robot->getCurrObs() - m_robot->predictMeas();
+    float weight = sqrtf( (2 * M_PI * m_meas_cov).determinant() );
+    weight = weight * expf( -0.5 * residue.transpose() * m_meas_cov.inverse() * residue );
+
+    return weight;
+}
+
+struct Point2D LMEKF2D::getLMEst() const {
+   return m_mu;
+}

--- a/src/FastSLAM/EKF_test.cpp
+++ b/src/FastSLAM/EKF_test.cpp
@@ -1,0 +1,75 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include "EKF.h"
+#include "robot-manager.h"
+
+
+TEST_CASE("Empty EKF"){
+    // set up
+    LMEKF2D* empty_landmark_ekf = new LMEKF2D();
+
+    SECTION( "Test: prediction does not change state" ){
+        struct Point2D expected_res = empty_landmark_ekf->getLMEst();
+        empty_landmark_ekf->predict();
+        struct Point2D actual_res = empty_landmark_ekf->getLMEst();
+
+        REQUIRE_THAT( expected_res.x, Catch::Matchers::WithinRel(actual_res.x, 0.001f) ||
+                      Catch::Matchers::WithinAbs(actual_res.x, 0.00001f) );
+        REQUIRE_THAT( expected_res.y, Catch::Matchers::WithinRel(actual_res.y, 0.001f) ||
+                      Catch::Matchers::WithinAbs(actual_res.y, 0.00001f) );
+    }
+
+    SECTION( "Test: empty robot manager handling" ) {
+
+        SECTION("Test update function") {
+            REQUIRE(empty_landmark_ekf->update() == KF_RET::EMPTY_ROBOT_MANAGER);
+        }
+
+        SECTION("Test calcCPD function") {
+            KF_RET res = static_cast<KF_RET>( empty_landmark_ekf->calcCPD() );
+            REQUIRE(res == KF_RET::EMPTY_ROBOT_MANAGER);
+        }
+
+    }
+
+    // tear-down
+    delete empty_landmark_ekf;
+}
+
+TEST_CASE("Non-empty EKF") {
+    // set-up
+    struct Pose2D init_pose = { .x = 0, .y =0, .theta_rad = 0 };
+    struct VelocityCommand2D init_cmd = { .vx_mps = 0, .wz_radps = 0 };
+    struct Point2D init_obs = { .x = 1, .y = 0 };
+    Eigen::Matrix2f init_cov;
+    init_cov << 1, 0,
+        0, 1;
+    std::shared_ptr<RobotManager2D> robot_instance = std::make_shared<Create3Manager>(init_pose, init_cmd, init_cov);
+
+    LMEKF2D* filled_landmark_ekf = new LMEKF2D(init_obs, init_cov, robot_instance);
+
+    SECTION("Test: prediction does not change state") {
+        struct Point2D expected_res = filled_landmark_ekf->getLMEst();
+        filled_landmark_ekf->predict();
+        struct Point2D actual_res = filled_landmark_ekf->getLMEst();
+
+        REQUIRE_THAT( expected_res.x, Catch::Matchers::WithinRel(actual_res.x, 0.001f) ||
+                      Catch::Matchers::WithinAbs(actual_res.x, 0.00001f) );
+        REQUIRE_THAT( expected_res.y, Catch::Matchers::WithinRel(actual_res.y, 0.001f) ||
+                      Catch::Matchers::WithinAbs(actual_res.y, 0.00001f) );
+
+    }
+
+    SECTION("Test: one step updates correctly") {
+        // TODO: requires mock-up robot manager
+    }
+
+    SECTION("Test: calculation of correct observation correspondence") {
+        //TODO: requires mock-up robot manager
+    }
+
+    // tear-down
+    delete filled_landmark_ekf;
+    robot_instance.reset();
+    REQUIRE(robot_instance.use_count() == 0); // check correct release of robot manager
+}

--- a/src/FastSLAM/EKF_test.cpp
+++ b/src/FastSLAM/EKF_test.cpp
@@ -47,6 +47,7 @@ TEST_CASE("Non-empty EKF") {
     std::shared_ptr<RobotManager2D> robot_instance = std::make_shared<Create3Manager>(init_pose, init_cmd, init_cov);
 
     LMEKF2D* filled_landmark_ekf = new LMEKF2D(init_obs, init_cov, robot_instance);
+    REQUIRE(robot_instance.use_count() == 2); // check correct ownership changes
 
     SECTION("Test: prediction does not change state") {
         struct Point2D expected_res = filled_landmark_ekf->getLMEst();
@@ -70,6 +71,4 @@ TEST_CASE("Non-empty EKF") {
 
     // tear-down
     delete filled_landmark_ekf;
-    robot_instance.reset();
-    REQUIRE(robot_instance.use_count() == 0); // check correct release of robot manager
 }

--- a/src/FastSLAM/math-util.cpp
+++ b/src/FastSLAM/math-util.cpp
@@ -1,5 +1,5 @@
 /**
- * @file probability.cpp
+ * @file math-util.cpp
  * @brief Implements common probability distributions and their samplers.
  */
 

--- a/src/FastSLAM/math-util_test.cpp
+++ b/src/FastSLAM/math-util_test.cpp
@@ -3,6 +3,30 @@
 #include "math-util.h"
 #include <math.h>
 
+TEST_CASE("Test overloaded 2D point addition operator") {
+   struct Point2D init = {.x = 1.2f, .y = -0.5f};
+   Eigen::Vector2f corrector(0.5f, 1.5f);
+
+   struct Point2D res = { .x = 1.7f, .y = 1.0f };
+   init += corrector;
+   REQUIRE_THAT( init.x, Catch::Matchers::WithinRel(res.x, 0.001f) ||
+                            Catch::Matchers::WithinAbs(res.x, 0.00001f) );
+   REQUIRE_THAT( init.y, Catch::Matchers::WithinRel(res.y, 0.001f) ||
+                            Catch::Matchers::WithinAbs(res.y, 0.00001f) );
+
+}
+
+TEST_CASE("Test overloaded observation diff operator") {
+
+   struct Observation2D one = { .range_m = 0, .bearing_rad = M_PI/2 };
+   struct Observation2D two = { .range_m = 1, .bearing_rad = 0 };
+   Eigen::Vector2f res(-1, M_PI/2);
+
+   REQUIRE(one - two == res);
+   REQUIRE(two - one == -res);
+
+}
+
 TEST_CASE("Test Gaussian Sampling - negative variance") {
    REQUIRE( isnan( MathUtil::sampleNormal(1.0f, -1.0f) ) );
 }

--- a/src/FastSLAM/robot-manager.cpp
+++ b/src/FastSLAM/robot-manager.cpp
@@ -1,0 +1,35 @@
+#include "robot-manager.h"
+
+
+Create3Manager::Create3Manager() {
+    std::cout << "Create 3 Manager created" << std::endl;
+}
+
+void Create3Manager::sampleIMU(){
+    (void) 0;
+}
+void Create3Manager::sampleLandMark() {
+    (void) 0;
+}
+void Create3Manager::sampleControl() {
+    (void) 0;
+}
+void Create3Manager::motionUpdate() {
+    (void) 0;
+}
+
+struct Observation2D Create3Manager::getCurrObs() const {
+    return m_curr_obs;
+}
+struct Observation2D Create3Manager::predictMeas() {
+    struct Observation2D ret = {.range_m = 0, .bearing_rad = 0, .landmarkID = 0};
+    return ret;
+}
+
+Eigen::Matrix2f Create3Manager::measJacobian(const struct Point2D mu_prev) const {
+   return Eigen::Matrix2f::Zero();
+}
+
+Eigen::Matrix2f Create3Manager::getMeasNoise() const {
+    return m_meas_noise;
+}


### PR DESCRIPTION
Implemented landmark EKF, along with various changes:

1. `RobotManager`, derived classes and function signatures for future integration
2. Two overloaded operators in `math-utils` for convenience
3. Unit tests for changes above (more EKF tests are needed, see ALP-109)