### PR TITLE
ALP-102: Add Particles and Particle Filter

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -38,7 +38,7 @@ jobs:
           sudo apt update
           xargs sudo apt -y install < ./package_list.txt
       - name: configure
-        run: cmake -B build -S . -DBUILD_TESTS=ON
+        run: cmake -B build -S . -DBUILD_TESTS=ON -DUSE_MOCK=ON
       - name: build
         run: cmake --build build -j ${nproc-2}
       - name: test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ find_package (Eigen3 3.4 REQUIRED NO_MODULE)
 # testing set up
 option(BUILD_TESTS "Build Tests" OFF)
 option(USE_MOCK "Use Mocked Robot" OFF)
+option(LM_CLEANUP "Enable landmark cleaning" OFF)
 if(BUILD_TESTS)
     find_package(Catch2 3 REQUIRED)
     include(CTest)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ cmake --build build -j2
 
 To build the tests, instead run:
 ```bash
-cmake -B build -S . -DBUILD_TESTS=ON
+cmake -B build -S . -DBUILD_TESTS=ON -DUSE_MOCK=ON
 cmake --build build -j2
 cd build && ctest
 ```

--- a/include/core-structs.h
+++ b/include/core-structs.h
@@ -10,59 +10,93 @@
 
 /** A point (position only) in the 2D plane. */
 struct Point2D {
-   float x;           // x-coordinate (scaled in meters)
-   float y;           // y-coordinate (scaled in meters)
+    float x;           // x-coordinate (scaled in meters)
+    float y;           // y-coordinate (scaled in meters)
 
-   struct Point2D& operator+=(const Eigen::Vector2f& rhs) {
-      x += rhs[0];
-      y += rhs[1];
-      return *this;
-   }
+    struct Point2D& operator+=(const Eigen::Vector2f& rhs) {
+       x += rhs[0];
+       y += rhs[1];
+       return *this;
+    }
 };
 
 /** A pose (position and orientation) in the 2D plane. */
 struct Pose2D {
-   float x;           // x-coordinate (scaled in meters)
-   float y;           // y-coordinate (scaled in meters)
-   float theta_rad;   // heading (radians) wrapped into [-pi, pi]
+    float x;           // x-coordinate (scaled in meters)
+    float y;           // y-coordinate (scaled in meters)
+    float theta_rad;   // heading (radians) wrapped into [-pi, pi]
 
+    /**
+     * @brief overloaded copy assignment operator
+     */
+    struct Pose2D& operator=(const struct Pose2D& other) {
+        if (this != &other) {
+            this->x = other.x;
+            this->y = other.y;
+            this->theta_rad = other.theta_rad;
+        }
+        return *this;
+    }
+
+    /**
+     * @brief overloaded sum operator, used for pose sampling
+     */
+    struct Pose2D& operator+=(const Eigen::Vector3f& rhs) {
+       x += rhs[0];
+       y += rhs[1];
+       theta_rad += rhs[2];
+       return *this;
+    }
 };
 
 /**
  * @brief Specifies motion for a 2D planar robot as robot-frame velocities.
  */
 struct VelocityCommand2D {
-   float vx_mps;      // Robot-frame "forward" linear velocity (meters per second)
-   float wz_radps;    // Robot-frame angular velocity (radians per second)
+    float vx_mps;      // Robot-frame "forward" linear velocity (meters per second)
+    float wz_radps;    // Robot-frame angular velocity (radians per second)
 };
 
 /**
  * @brief scoped enum for handling non-observation landmarks
  */
-enum class NONE_OBS_LM {prediction = -1, unknown_lm = -2};
+enum class NONE_OBS_LM {prediction = -1};
 
 /** An observation of a landmark as viewed from the robot's perspective. */
 struct Observation2D {
-   float range_m;     // Range from the robot to the landmark (meters)
-   float bearing_rad; // Bearing in the robot's frame to the landmark (radians)
+    float range_m;     // Range from the robot to the landmark (meters)
+    float bearing_rad; // Bearing in the robot's frame to the landmark (radians)
 
-   /**
-    * @brief Stores the landmark signature corresponding to the observation.
-    *    Set to std::nullopt to represent an unknown correspondence variable.
-    *
-    * TODO: When DA is unknown, each particle's correspondence may differ.
-    *    Populating/clearing this field may be more trouble than it's worth...
-    */
-   std::optional<int> landmarkID;
+    /**
+     * @brief Stores the landmark signature corresponding to the observation.
+     *    Set to std::nullopt to represent an unknown correspondence variable.
+     *
+     * TODO: When DA is unknown, each particle's correspondence may differ.
+     *    Populating/clearing this field may be more trouble than it's worth...
+     */
+    std::optional<int> landmarkID;
 
-   /**
-    * @brief overloaded difference operator for residual calculation
-    * @return an eigen column vector representing the residual
-    */
-   Eigen::Vector2f operator-(const struct Observation2D& rhs) const {
-      float range_diff = this->range_m - rhs.range_m;
-      float bearing_diff = this->bearing_rad - rhs.bearing_rad;
+    /**
+     * @brief overloaded difference operator for residual calculation
+     * @return an eigen column vector representing the residual
+     */
+    Eigen::Vector2f operator-(const struct Observation2D& rhs) const {
+       float range_diff = this->range_m - rhs.range_m;
+       float bearing_diff = this->bearing_rad - rhs.bearing_rad;
 
-      return Eigen::Vector2f(range_diff, bearing_diff);
-   }
+       return Eigen::Vector2f(range_diff, bearing_diff);
+    }
+
+    /**
+     * @brief overloaded copy assignment operator for moving observations
+     * @param[in] other: observation to be copied
+     */
+    struct Observation2D& operator=(const struct Observation2D& other) {
+        if (this != &other){
+            this->range_m = other.range_m;
+            this->bearing_rad = other.bearing_rad;
+            this->landmarkID = other.landmarkID;
+        }
+        return *this;
+    }
 };

--- a/include/math-util.h
+++ b/include/math-util.h
@@ -52,9 +52,6 @@ std::pair<float, float> bodyToWorld2D(const std::pair<float, float>& aBody_quant
  *    C++ has a built in normal distribution template, see:
  *    https://en.cppreference.com/w/cpp/numeric/random/normal_distribution
  *
- *    TODO: Ensure we're talking about stddev and variance correctly,
- *       because ProbRob has a typo somewhere in Table 5.4. Beware!
- *
  * @param[in]     aMean       Mean of the sampled Normal distribution
  * @param[in]     aVariance   Variance of the sampled Normal distribution
  *
@@ -62,5 +59,42 @@ std::pair<float, float> bodyToWorld2D(const std::pair<float, float>& aBody_quant
  */
 float sampleNormal( const float aMean, const float aVariance );
 
+/**
+ * @brief Generates a random sample from the Uniform [min, max)
+ *
+ * @param[in] aMin: minimum value of the range
+ * @param[in] aMax: maximum value of the range
+ *
+ * @return Random value, distributed according to the defined Uniform
+ */
+float sampleUniform( const float& aMin, const float& aMax );
+
+/**
+ * @brief Finds the distance between two points
+ *
+ * @param[in] aPointA: a 2D point
+ * @param[in] aPointB: a 2D point
+ * @return the absolute distance between two points
+ */
+float findDist( const struct Point2D& aPointA, const struct Point2D& aPointB );
+
+/**
+ * @brief overloaded version of findDist, used specifically for robot and landmark
+ *
+ * @param[in] aPointA:  landmark position
+ * @param[in] aRobPose: robot pose
+ * @return distance between landmark and robot
+ */
+float findDist( const struct Point2D& aLandMark, const struct Pose2D& aRobPose );
+
+/**
+ * @brief generate a cumulative cdf table based on pdf weights
+ *
+ * @param[in] aPdfVec: vector containing pdf values
+ * @param[in] aTargetVec: reference to the vector containing results
+ * @return sum of the all elements
+ */
+template< class T >
+T genCDF( const std::vector<T>& aPdfVec, std::vector<T>& aTargetVec );
 
 }; // namespace MathUtil

--- a/include/particle-filter.h
+++ b/include/particle-filter.h
@@ -1,0 +1,205 @@
+/**
+ * @file particle-filter.h
+ * @brief defines the particle filter class, including re-sampling methods
+ */
+
+#include "core-structs.h"
+#include "math-util.h"
+#include "EKF.h"
+#include <unordered_map>
+#include <queue>
+
+enum class PF_RET{ SUCCESS = 0, EMPTY_ROBOT_MANAGER = -1, MATRIX_INVERSION_ERROR = -2, UPDATE_ERROR = -3 };
+constexpr unsigned int DEFAULT_NUM_PARTICLE = 50;
+constexpr float DEFAULT_IMPORTANCE_FACTOR = 0.5;
+
+class FastSLAMParticles {
+
+private:
+    /**
+     * @brief starting importance factor for determining new lm sightings
+     */
+    float m_importance_factor;
+
+    /**
+     * @brief local copy of the current robot pose, used to ensure timing
+     */
+    Pose2D m_robot_pose;
+
+    /**
+     * @brief current particle data association label
+     * @details used to mark current measurement association
+     */
+    int m_data_label;
+
+    /**
+     * @brief collection of all landmark EKFs
+     */
+    std::vector<std::pair<std::unique_ptr<LMEKF2D>, int>> m_lmekf_bank;
+
+    /**
+     * @brief shared ptr to robot manager instance,
+     * needed to instantiate new KFs
+     */
+     std::shared_ptr<RobotManager2D> m_robot;
+
+    /**
+     * @brief get landmark data association label from EKFs given a measurement
+     * @details queries EKF for maximum likelihood of correspondence
+     *
+     * @param[in] curr_obs: current robot observation
+     * @return data association index
+     */
+    int matchLandmark(const struct Observation2D& curr_obs);
+
+    /**
+     * @brief update specific landmark belief given new measurement
+     *
+     * @param[in] curr_obs: current robot observation
+     */
+    PF_RET updateLMBelief(const struct Observation2D& curr_obs);
+
+    /**
+     * @brief update local copy of current robot pose
+     */
+    PF_RET updatePose(const struct Pose2D& new_pose);
+
+
+#ifdef LM_CLEANUP
+    /**
+     * @brief clean up dubious features by keeping track of sightings
+     * @details keep tracks of landmark sightings using the sightings count
+     */
+     void cleanUpSightings();
+#endif
+
+public:
+
+    FastSLAMParticles() = delete;
+
+    /**
+     * @brief class constructor; must provide importance factor, robot starting pose
+     * and robot manager
+     */
+    explicit FastSLAMParticles(float p_0, const struct Pose2D& starting_pose,
+                               std::shared_ptr<RobotManager2D> rob_mgr):
+    m_importance_factor(p_0), m_robot_pose(starting_pose), m_robot(rob_mgr){
+        m_data_label = -1;
+    }
+
+    /**
+     * @brief copy constructor, used to duplicate particles during the sampling process
+     *
+     * @param[in] part: particle to copy from
+     */
+    FastSLAMParticles(const FastSLAMParticles& part);
+
+    /**
+     * @brief check for the total number of tracked landmakrs
+     * @return current number of tracked landmarks */
+    int getNumLandMark() const { return m_lmekf_bank.size(); };
+
+    /**
+     * @brief class template method, runs landmark data association and belief update
+     *
+     * @param[in] new_obs: new robot landmark observation, unclassified
+     * @param[in] new_pose: new robot pose estimate
+     * @return maximum importance factor for resampling
+     */
+    float updateParticle(const struct Observation2D& new_obs,
+                         const struct Pose2D& new_pose);
+};
+
+class FastSLAMPF {
+private:
+
+    /**
+     * @brief key-value pairs of index and particles
+     */
+    std::unordered_map<int, std::unique_ptr<FastSLAMParticles>> m_particle_set;
+
+    /**
+     * @brief importance factors associated with particles
+     */
+    std::vector<float> m_particle_weights;
+
+    /**
+     * @brief point to robot manager
+     */
+    std::shared_ptr<RobotManager2D> m_robot;
+
+    /**
+     * @brief number of particles in the filter
+     */
+    unsigned int m_num_particles;
+
+    /**
+     * @brief sample robot pose; this function is probabilistic
+     * @details credit: https://stackoverflow.com/questions/6142576
+     * /sample-from-multivariate-normal-gaussian-distribution-in-c
+     *
+     * @param[in] a_pose_mean: collected mean pose from sensor
+     * @return a 2D pose sampled from the robot's motion distribution
+     */
+    struct Pose2D samplePose(const struct Pose2D& a_pose_mean);
+
+    /**
+     * @brief resample particles with replacement based on the weights
+     */
+    void reSampleParticles();
+
+public:
+
+    FastSLAMPF() = delete;
+
+    /**
+     * @brief full constructor, need robot manager, number of particles, starting
+     * pose, and new landmark importance factor
+     *
+     * @param[in] rob_ptr: shared pointer to a 2D robot manager
+     * @param[in] num_particles: number of particles in the filter
+     * @param[in] starting_pose: initial robot pose
+     * @param[in] lm_importance_factor: importance factor for landmark MLE
+     */
+     FastSLAMPF(std::shared_ptr<RobotManager2D> rob_ptr,
+                unsigned int num_particles,
+                const struct Pose2D& starting_pose,
+                const float& lm_importance_factor);
+
+    /**
+     * @brief simplified constructor, specifiy robot start around (0,0,0)
+     * and use 50 particles
+     * @details calls the class delegate constructor specified above
+     *
+     * @param[in] rob_ptr: shared pointer to a 2D robot manager
+     */
+     FastSLAMPF(std::shared_ptr<RobotManager2D> rob_ptr);
+
+
+    /**
+     * @brief update and resample particles given new pose mean and lm observation
+     *
+     * @param[in] a_robot_pose_mean: robot mean pose, sampled directly from sensors
+     * @param[in] a_sighting_queue: a queue to all landmark sightings
+     */
+    void updateFilter(const struct Pose2D& a_robot_pose_mean,
+                     std::queue<struct Observation2D>& a_sighting_queue);
+
+    /**
+     * @brief extract filter estimate on robot pose and landmark position
+     *
+     * @return a copied instance of the particle that reflect the SLAM estimations
+     * the returned pointer is not the internal state, but rather a copy of the internal state
+     */
+     std::unique_ptr<FastSLAMParticles> returnEst();
+
+    /**
+     * @brief draw one particle (with replacement) based on the random generated sample
+     * @details: this method carries out weighted random sampling with a cdf vector; the
+     * method needs to be used with a random number generator (see MathUtils::sampleUniform)
+     *
+     * @param[in] cdf_vec: cdf vector containing cumulative sum of all weights
+     * @param[in] sample: randomly-generated number in range of the cdf table
+     */
+    int drawWithReplacement(const std::vector<float>& cdf_vec, float sample);
+};

--- a/src/FastSLAM/CMakeLists.txt
+++ b/src/FastSLAM/CMakeLists.txt
@@ -2,6 +2,8 @@ add_library(FastSLAMLib
    math-util.cpp
    EKF.cpp
    create3-manager.cpp
+   particle-filter.cpp
+   particles.cpp
 )
 if(USE_MOCK)
     target_sources(FastSLAMLib PUBLIC mock-manager2d.cpp)
@@ -26,9 +28,11 @@ if(BUILD_TESTS)
   )
 
   add_executable(test_EKF EKF_test.cpp)
+  add_executable(test_Particle particle-filter_test.cpp)
 
   if(USE_MOCK)
     target_compile_definitions(test_EKF PUBLIC USE_MOCK)
+    target_compile_definitions(test_Particle PUBLIC USE_MOCK)
     add_executable(test_MockManager2d mock-manager2d_test.cpp)
     target_compile_definitions(test_MockManager2d PUBLIC USE_MOCK)
     target_link_libraries(test_MockManager2d
@@ -42,11 +46,25 @@ if(BUILD_TESTS)
   else()
     target_compile_definitions(test_EKF PUBLIC USE_SIM)
   endif()
+
+  if (LM_CLEANUP)
+    target_compile_definitions(FastSLAMLib PUBLIC LM_CLEANUP)
+  endif()
+
   target_link_libraries(test_EKF
                         PRIVATE Catch2::Catch2WithMain
                         FastSLAMLib)
   catch_discover_tests(test_EKF)
   target_include_directories(test_EKF PUBLIC
+    "${PROJECT_BINARY_DIR}"
+    "${PROJECT_SOURCE_DIR}/include"
+  )
+
+  target_link_libraries(test_Particle
+                        PRIVATE Catch2::Catch2WithMain
+                        FastSLAMLib)
+  catch_discover_tests(test_Particle)
+  target_include_directories(test_Particle PUBLIC
     "${PROJECT_BINARY_DIR}"
     "${PROJECT_SOURCE_DIR}/include"
   )

--- a/src/FastSLAM/create3-manager.cpp
+++ b/src/FastSLAM/create3-manager.cpp
@@ -21,15 +21,24 @@ struct Pose2D Create3Manager::motionUpdate() {
 struct Observation2D Create3Manager::getCurrObs() const {
     return m_curr_obs;
 }
-struct Observation2D Create3Manager::predictMeas(const struct Point2D mu_prev) {
+
+struct Point2D Create3Manager::inverseMeas(const struct Pose2D& rob_pose, const struct Observation2D &curr_obs) const{
+    return {.x = 0, .y = 0};
+}
+
+struct Observation2D Create3Manager::predictMeas(const struct Point2D& mu_prev) {
     struct Observation2D ret = {.range_m = 0, .bearing_rad = 0, .landmarkID = 0};
     return ret;
 }
 
-Eigen::Matrix2f Create3Manager::measJacobian(const struct Point2D mu_prev) const {
+Eigen::Matrix2f Create3Manager::measJacobian(const struct Point2D& mu_prev) const {
    return Eigen::Matrix2f::Zero();
 }
 
 Eigen::Matrix2f Create3Manager::getMeasNoise() const {
     return m_meas_noise;
+}
+
+Eigen::Matrix3f Create3Manager::getProcessNoise() const {
+    return m_process_noise;
 }

--- a/src/FastSLAM/math-util.cpp
+++ b/src/FastSLAM/math-util.cpp
@@ -39,3 +39,36 @@ float MathUtil::sampleNormal( const float aMean, const float aVariance ){
 
    return d(gen);
 }
+
+float MathUtil::sampleUniform( const float& aMin, const float& aMax ){
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_real_distribution<> dist(aMin, aMax);
+    return dist(gen);
+}
+
+float MathUtil::findDist( const struct Point2D& aPointA, const struct Point2D& aPointB ){
+   return sqrtf( powf((aPointA.x - aPointB.x), 2) + powf((aPointA.y - aPointB.y), 2) );
+}
+
+float MathUtil::findDist( const struct Point2D& aLandMark, const struct Pose2D& aRobPose ){
+   return sqrtf( powf((aLandMark.x - aRobPose.x), 2) + powf((aLandMark.y - aRobPose.y), 2) );
+}
+
+template< class T >
+T MathUtil::genCDF( const std::vector<T>& aPdfVec, std::vector<T>& aTargetVec ){
+
+    if (aPdfVec.empty()) return static_cast<T>(0);
+
+    T running_sum = static_cast<T>(0);
+    for (int i = 0; i < aPdfVec.size(); i++){
+       running_sum += aPdfVec[i];
+       aTargetVec.push_back(running_sum);
+    }
+    return running_sum;
+}
+
+template float MathUtil::genCDF<float>(const std::vector<float> &aPdfVec,
+                                       std::vector<float> &aTargetVec);
+template int MathUtil::genCDF<int>(const std::vector<int> &aPdfVec,
+                                       std::vector<int> &aTargetVec);

--- a/src/FastSLAM/math-util_test.cpp
+++ b/src/FastSLAM/math-util_test.cpp
@@ -136,3 +136,38 @@ TEST_CASE("Test foward-inverse transform: bodyToWorld") {
                             Catch::Matchers::WithinAbs(target.second, 0.00001f) );
 
 }
+
+TEST_CASE( "Test CDF table generation" ){
+
+   SECTION( "test vector of float" ){
+      std::vector<float> pdf {0.1, 0.3, 0.4, 0.2};
+      std::vector<float> cdf_target {0.1, 0.4, 0.8, 1};
+      std::vector<float> cdf;
+      MathUtil::genCDF(pdf, cdf);
+      int idx = 0;
+      for (const auto& it: cdf_target) {
+         REQUIRE_THAT( it, Catch::Matchers::WithinRel(cdf[idx], 0.001f) ||
+                       Catch::Matchers::WithinAbs(cdf[idx], 0.00001f) );
+         idx++;
+      }
+   }
+
+   SECTION( "test vector of int" ){
+      std::vector<int> pdf {0, 1, 2, 3};
+      std::vector<int> cdf_target {0, 1, 3, 6};
+      std::vector<int> cdf;
+      MathUtil::genCDF(pdf, cdf);
+      int idx = 0;
+      for (const auto& it: cdf_target) {
+         REQUIRE( it == cdf[idx] );
+         idx++;
+      }
+   }
+
+   SECTION( "test empty vector" ){
+      std::vector<int> pdf;
+      std::vector<int> cdf;
+      MathUtil::genCDF(pdf, cdf);
+      REQUIRE( cdf.empty() );
+   }
+}

--- a/src/FastSLAM/mock-manager2d.cpp
+++ b/src/FastSLAM/mock-manager2d.cpp
@@ -31,7 +31,7 @@ struct Observation2D MockManager2D::getCurrObs() const {
     return m_curr_obs;
 }
 
-struct Observation2D MockManager2D::predictMeas(const struct Point2D mu_prev) {
+struct Observation2D MockManager2D::predictMeas(const struct Point2D& mu_prev) {
     float range = sqrtf( powf((mu_prev.x - m_curr_pose.x), 2) + powf((mu_prev.y - m_curr_pose.y), 2) );
     float bearing = atan2f((mu_prev.y - m_curr_pose.y), (mu_prev.x - m_curr_pose.x)) - m_curr_pose.theta_rad;
 
@@ -40,7 +40,7 @@ struct Observation2D MockManager2D::predictMeas(const struct Point2D mu_prev) {
     return {.range_m = range, .bearing_rad = bearing, .landmarkID = static_cast<int>(NONE_OBS_LM::prediction)};
 }
 
-Eigen::Matrix2f MockManager2D::measJacobian(const struct Point2D mu_prev) const {
+Eigen::Matrix2f MockManager2D::measJacobian(const struct Point2D& mu_prev) const {
     float dx = mu_prev.x - m_curr_pose.x;
     float dy = mu_prev.y - m_curr_pose.y;
     Eigen::Matrix2f G;
@@ -57,15 +57,24 @@ Eigen::Matrix2f MockManager2D::measJacobian(const struct Point2D mu_prev) const 
     return G;
 }
 
+struct Point2D MockManager2D::inverseMeas(const struct Pose2D& rob_pose,
+                           const struct Observation2D& curr_obs) const {
+    float x = curr_obs.range_m * cosf( curr_obs.bearing_rad + rob_pose.theta_rad );
+    float y = curr_obs.range_m * sinf( curr_obs.bearing_rad + rob_pose.theta_rad );
+
+    return {.x = x, .y = y};
+}
 
 Eigen::Matrix2f MockManager2D::getMeasNoise() const {
     return m_meas_noise;
 }
 
+Eigen::Matrix3f MockManager2D::getProcessNoise() const {
+    return m_process_noise;
+}
+
 void MockManager2D::setObs(const struct Observation2D& new_obs){
-    m_curr_obs.range_m = new_obs.range_m;
-    m_curr_obs.bearing_rad = new_obs.bearing_rad;
-    m_curr_obs.landmarkID = new_obs.landmarkID;
+    m_curr_obs = new_obs;
 }
 
 void MockManager2D::setControl(const struct VelocityCommand2D& new_ctrl){

--- a/src/FastSLAM/mock-manager2d_test.cpp
+++ b/src/FastSLAM/mock-manager2d_test.cpp
@@ -13,7 +13,7 @@ TEST_CASE( "Test MockManager Numerical Sim" ) {
     Eigen::Matrix2f init_cov;
     init_cov << 1, 0,
         0, 1;
-    std::unique_ptr<MockManager2D> test_manager = std::make_unique<MockManager2D>(init_pose, init_cmd, init_cov);
+    std::unique_ptr<MockManager2D> test_manager = std::make_unique<MockManager2D>(init_pose, init_cmd, init_cov, 0);
 
     SECTION( "MockManager: Test Motion Update" ){
         struct Pose2D expected = { .x = 1, .y = 0, .theta_rad = 0 };
@@ -149,6 +149,17 @@ TEST_CASE( "Test MockManager Numerical Sim" ) {
 
     }
 
+    SECTION( "MockManager: test inverse measurement function" ){
+
+        SECTION( "Position 1: Landmark behind robot" ){
+            struct Point2D expected = {.x = -1, .y = 0};
+            auto res = test_manager->inverseMeas({.x = 0, .y = 0}, {.range_m = 1, .bearing_rad = M_PI});
+            REQUIRE_THAT( res.x, Catch::Matchers::WithinRel(expected.x, 0.001f) ||
+                          Catch::Matchers::WithinAbs(expected.x, 0.00001f) );
+            REQUIRE_THAT( res.y, Catch::Matchers::WithinRel(expected.y, 0.001f) ||
+                          Catch::Matchers::WithinAbs(expected.y, 0.00001f) );
+        }
+    }
 }
 
 #endif // USE_MOCK

--- a/src/FastSLAM/particle-filter.cpp
+++ b/src/FastSLAM/particle-filter.cpp
@@ -1,0 +1,104 @@
+/**
+ * @file particle-filter.cpp
+ * @brief implements the particle filter class
+ */
+
+#include "particle-filter.h"
+
+FastSLAMPF::FastSLAMPF(std::shared_ptr<RobotManager2D> rob_ptr,
+                       unsigned int num_particles,
+                       const struct Pose2D& starting_pose,
+                       const float& lm_importance_factor):
+    m_robot(rob_ptr),
+    m_num_particles(DEFAULT_NUM_PARTICLE){
+
+    for (int i = 0; i < m_num_particles; i++) {
+        std::unique_ptr<FastSLAMParticles> new_particle = std::make_unique<FastSLAMParticles>
+            (lm_importance_factor, starting_pose, m_robot);
+        auto particle_pair = std::make_pair(i, std::move(new_particle));
+        m_particle_set.insert(std::move(particle_pair));
+
+        m_particle_weights.push_back(1.0f / static_cast<float>(m_num_particles));
+    }
+}
+
+
+FastSLAMPF::FastSLAMPF(std::shared_ptr<RobotManager2D> rob_ptr):
+    FastSLAMPF(rob_ptr, DEFAULT_NUM_PARTICLE,
+               {.x = 0, .y = 0, .theta_rad = 0}, DEFAULT_IMPORTANCE_FACTOR) {
+}
+
+struct Pose2D FastSLAMPF::samplePose(const struct Pose2D& a_pose_mean) {
+    Eigen::Matrix3f l_cholesky;
+    Eigen::LLT<Eigen::Matrix3f> cholSolver(m_robot->getProcessNoise());
+    if (cholSolver.info()==Eigen::Success) {
+        // Use cholesky solver
+        l_cholesky = cholSolver.matrixL();
+    } else {
+        // Use eigen solver
+        Eigen::SelfAdjointEigenSolver<Eigen::Matrix3f> eigenSolver(m_robot->getProcessNoise());
+        l_cholesky = eigenSolver.eigenvectors()
+            * eigenSolver.eigenvalues().cwiseSqrt().asDiagonal();
+    }
+    Eigen::Vector3f z = Eigen::Vector3f::Zero();
+    for (auto& it: z){
+        it = MathUtil::sampleNormal(0.0f, 1.0f);
+    }
+    struct Pose2D ret = a_pose_mean;
+    ret += l_cholesky * z;
+    return ret;
+}
+
+int FastSLAMPF::drawWithReplacement(const std::vector<float>& cdf_vec, float sample){
+    int start = 0;
+    int end = cdf_vec.size()-1;
+    if (sample < 0 || sample > cdf_vec[end]) return -1;
+
+    // binary search, if the sample falls between the [prev, next) interval,
+    // then consider the sample drawn from that interval
+    int middle;
+    while (start != end) {
+        middle = (start + end) / 2;
+        if (sample >= cdf_vec[middle]) {
+            start = middle+1;
+        } else {
+            end = middle;
+        }
+    }
+    return middle;
+}
+
+void FastSLAMPF::reSampleParticles(){
+    std::vector<float> cdf_table;
+    float total_weight = MathUtil::genCDF(m_particle_weights, cdf_table);
+    float sampled_weight;
+    std::unordered_map<int, std::unique_ptr<FastSLAMParticles>> aux_set;
+
+    for (const auto& it: m_particle_set){
+        sampled_weight = MathUtil::sampleUniform(0.0, total_weight);
+        int sampled_idx = drawWithReplacement(cdf_table, sampled_weight);
+        // leave original particle if sampling goes wrong
+        sampled_idx = sampled_idx >= 0 ? sampled_idx : it.first;
+        std::unique_ptr<FastSLAMParticles> particle_drew =
+            std::make_unique<FastSLAMParticles>(*m_particle_set[sampled_idx]);
+        aux_set.insert({it.first, std::move(particle_drew)});
+    }
+
+    m_particle_set = std::move(aux_set);
+
+}
+
+void FastSLAMPF::updateFilter(const struct Pose2D &a_robot_pose_mean,
+                         std::queue<struct Observation2D> &a_sighting_queue) {
+    while (!a_sighting_queue.empty()){
+        int idx = 0;
+        for (auto& it: m_particle_set){
+            auto rob_pose_sampled = samplePose(a_robot_pose_mean);
+            m_particle_weights[idx] += it.second->updateParticle(
+                a_sighting_queue.front(), rob_pose_sampled);
+            idx++;
+        }
+        a_sighting_queue.pop();
+    }
+    reSampleParticles();
+}

--- a/src/FastSLAM/particle-filter_test.cpp
+++ b/src/FastSLAM/particle-filter_test.cpp
@@ -1,0 +1,68 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include "robot-manager.h"
+#include "particle-filter.h"
+
+TEST_CASE( "Default Particle" ){
+    // set-up
+    struct Pose2D init_pose = { .x = 0, .y =0, .theta_rad = 0 };
+    struct VelocityCommand2D init_cmd = { .vx_mps = 1, .wz_radps = 0 };
+    struct Point2D init_obs = { .x = 0, .y = 1 };
+    Eigen::Matrix2f init_cov;
+    init_cov << 1, 0,
+        0, 1;
+
+#ifdef USE_MOCK
+    std::shared_ptr<RobotManager2D> test_manager =
+        std::make_shared<MockManager2D>(init_pose, init_cmd, init_cov, 0);
+    std::unique_ptr<FastSLAMParticles> test_particle =
+        std::make_unique<FastSLAMParticles>(0.5, init_pose, test_manager);
+#else
+    std::unique_ptr<FastSLAMParticles> test_particle =
+        std::make_unique<FastSLAMParticles>(0.5, starting_pose, nullptr);
+#endif //USE_MOCK
+
+    REQUIRE( test_particle->getNumLandMark() == 0 );
+
+    SECTION( "Test copy construction" ){
+        std::unique_ptr<FastSLAMParticles> copied_particle =
+            std::make_unique<FastSLAMParticles>(*test_particle);
+        REQUIRE(copied_particle != nullptr);
+        REQUIRE(copied_particle->getNumLandMark() == 0);
+    }
+
+    SECTION( "Test update landmark" ){
+        float res = test_particle->updateParticle({.range_m = 1, .bearing_rad = 0},
+                                      {.x = 0, .y = 1, .theta_rad = 0});
+        REQUIRE(res != static_cast<float>(PF_RET::UPDATE_ERROR));
+        REQUIRE(test_particle->getNumLandMark() == 1);
+    }
+
+}
+
+TEST_CASE( "Test Particle Filter" ){
+    // set-up
+    struct Pose2D init_pose = { .x = 0, .y =0, .theta_rad = 0 };
+    struct VelocityCommand2D init_cmd = { .vx_mps = 1, .wz_radps = 0 };
+    struct Point2D init_obs = { .x = 0, .y = 1 };
+    Eigen::Matrix2f init_cov;
+    init_cov << 1, 0,
+        0, 1;
+
+#ifdef USE_MOCK
+    std::shared_ptr<RobotManager2D> test_manager =
+        std::make_shared<MockManager2D>(init_pose, init_cmd, init_cov, 0);
+    std::unique_ptr<FastSLAMPF> test_pf =
+        std::make_unique<FastSLAMPF>(test_manager);
+#else
+    std::unique_ptr<FastSLAMPF> test_pf = std::make_unique<FastSLAMPF>(nullptr);
+#endif //USE_MOCK
+
+    std::vector<float> cdf_table = {0.1, 0.4, 0.8, 1};
+
+    REQUIRE( test_pf->drawWithReplacement(cdf_table, 0.5) == 2);
+    REQUIRE( test_pf->drawWithReplacement(cdf_table, 0.09) == 0);
+    REQUIRE( test_pf->drawWithReplacement(cdf_table, 0.4) == 2);
+    REQUIRE( test_pf->drawWithReplacement(cdf_table, 2) == -1);
+
+}

--- a/src/FastSLAM/particles.cpp
+++ b/src/FastSLAM/particles.cpp
@@ -1,0 +1,122 @@
+/**
+ * @file particles.cpp
+ * @brief implements the FastSLAM 2D particles class
+ */
+
+#include "particle-filter.h"
+
+FastSLAMParticles::FastSLAMParticles(const FastSLAMParticles& part):
+    m_importance_factor(part.m_importance_factor),
+    m_robot_pose(part.m_robot_pose),
+    m_data_label(part.m_data_label),
+    m_robot(part.m_robot){
+    for (const auto& it: m_lmekf_bank){
+        m_lmekf_bank.push_back(std::make_pair(std::make_unique<LMEKF2D>(*it.first.get()), it.second));
+    }
+}
+
+int FastSLAMParticles::matchLandmark(const struct Observation2D& curr_obs) {
+    float w_0 = this->m_importance_factor;
+    int landmark_id = m_lmekf_bank.size();
+    int idx = 0;
+
+    for (auto const& it: m_lmekf_bank) {
+        it.first->updateObservation(curr_obs);
+        float w_n = it.first->calcCPD();
+        landmark_id = w_n > w_0 ? idx : landmark_id;
+        idx++;
+    }
+
+    m_data_label = landmark_id;
+
+    return landmark_id;
+}
+
+PF_RET FastSLAMParticles::updateLMBelief(const struct Observation2D& curr_obs){
+    if (m_robot == nullptr) {
+        // appropriate error handling here
+        std::cout << "non-robot manager specified" << std::endl;
+        return PF_RET::EMPTY_ROBOT_MANAGER;
+    }
+    if (m_data_label == m_lmekf_bank.size()) {
+        // initiate new EKF
+        struct Point2D proposed_mean = m_robot->inverseMeas(m_robot_pose, curr_obs);
+        auto meas_jacobian = m_robot->measJacobian(proposed_mean);
+
+        Eigen::Matrix2f proposed_cov;
+        if (meas_jacobian.determinant() == 0) {
+            // log error here
+            std::cout << "Non-invertible matrix" << std::endl;
+            proposed_cov = Eigen::Matrix2f::Identity();
+        } else {
+            proposed_cov = meas_jacobian.inverse() * m_robot->getMeasNoise() *
+                meas_jacobian.inverse().transpose();
+        }
+
+        std::unique_ptr<LMEKF2D> new_lmefk =
+            std::make_unique<LMEKF2D>(proposed_mean, proposed_cov, m_robot);
+        m_lmekf_bank.push_back(std::make_pair(std::move(new_lmefk), 1));
+        return PF_RET::SUCCESS;
+    } else {
+        LMEKF2D * filter_to_update = m_lmekf_bank[m_data_label].first.get();
+        filter_to_update->updateObservation(curr_obs);
+        auto status = filter_to_update->update();
+
+        switch (status) {
+            case KF_RET::EMPTY_ROBOT_MANAGER:
+                // error handling
+                std::cout << "non-robot manager specified" << std::endl;
+                return PF_RET::EMPTY_ROBOT_MANAGER;
+            case KF_RET::MATRIX_INVERSION_ERROR:
+                // error handling
+                std::cout << "Kalman Filter failed to converge" << std::endl;
+                return PF_RET::MATRIX_INVERSION_ERROR;
+            default:
+                m_lmekf_bank[m_data_label].second++;
+                break;
+        }
+    }
+    return PF_RET::SUCCESS;
+}
+
+#ifdef LM_CLEANUP
+void FastSLAMParticles::cleanUpSightings() {
+    int i = 0;
+    for (auto& it: m_lmekf_bank) {
+        if (i == m_data_label) {
+            i++;
+            continue;
+        }
+
+        if ( MathUtil::findDist(it.first->getLMEst(), m_robot_pose) <=
+             m_robot->getPerceptualRange() ) {
+            it.second--;
+        }
+    }
+}
+#endif
+
+PF_RET FastSLAMParticles::updatePose(const struct Pose2D& new_pose) {
+    m_robot_pose = new_pose;
+    return PF_RET::SUCCESS;
+}
+
+float FastSLAMParticles::updateParticle(const struct Observation2D& new_obs,
+                                      const struct Pose2D& new_pose) {
+    if (m_robot == nullptr) {
+        std::cout << "No robot manager specified" << std::endl;
+        return -1.0;
+    }
+    int res_code = 0;
+    res_code += static_cast<int>(updatePose(new_pose));
+    matchLandmark(new_obs);
+    res_code += static_cast<int>(updateLMBelief(new_obs));
+
+#ifdef LM_CLEANUP
+    cleanUpSightings();
+#endif //LM_CLEANUP
+
+    return res_code == static_cast<int>(PF_RET::SUCCESS) ?
+        m_lmekf_bank[m_data_label].first->calcCPD() :
+        static_cast<float>(PF_RET::UPDATE_ERROR);
+}

--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -1130,7 +1130,7 @@ force_tab_after_define          = false    # true/false
 # The number of columns to indent per level. Usually 2, 3, 4, or 8.
 #
 # Default: 8
-indent_columns                  = 3        # unsigned number
+indent_columns                  = 4        # unsigned number
 
 # Whether to ignore indent for the first continuation line. Subsequent
 # continuation lines will still be indented to match the first.


### PR DESCRIPTION
Specific breakdown below:

ALP-102: Start Particles class

ALP-102: Rebase onto dev

ALP-102: Specify copy control for particles

ALP-102: Add particle filter interfaces

ALP-102: Add docstrings to particle filter class

ALP-102: Finish particle filter class

- Add math utils and unit tests
- still need to implement pose multivariate sampling

ALP-102: Add multivariate sampling

ALP-102: Fix particle filter bugs