### PR TITLE
Es/alp 118 implement proper ekf unit tests using mock manager

### DIFF
--- a/docs/ekf_verify.m
+++ b/docs/ekf_verify.m
@@ -1,5 +1,5 @@
 %% Verify EKF one step update
-% by Emma Slaught & Will Wu
+% by Emma Slaght & Will Wu
 clear; clc;
 
 %% set up test

--- a/docs/ekf_verify.m
+++ b/docs/ekf_verify.m
@@ -1,0 +1,75 @@
+%% Verify EKF one step update
+% by Emma Slaught & Will Wu
+clear; clc;
+
+%% set up test
+init_pose = [0; 0; 0]; %initial pose of the robot [x ; y; theta]
+init_sigma = eye(2);
+
+%current belief of where landmark is, POLAR [range, bearing] -- in ROBOT frame
+p_init_obs = [1; pi/2]; 
+c_init_obs = [p_init_obs(1) * cos(p_init_obs(2)); 
+              p_init_obs(1) * sin(p_init_obs(2))];
+
+% current belief of landmark position in world frame
+prev_lm_belief = [c_init_obs(1) + init_pose(1) ; c_init_obs(2) + init_pose(2)];
+
+vel_cmd = [1; 0; 0];
+new_pose = [(vel_cmd(1) * cos(init_pose(3))) + init_pose(1) ; 
+            (vel_cmd(1) * sin(init_pose(3))) + init_pose(2) ; 
+             vel_cmd(2) + init_pose(3)];
+
+% hypothetical new obs after movement, in polar, robot frame
+p_new_obs = [1.5; pi/4]; 
+
+% what the robot thinks it will see based on current position and prev
+% landmark belief, in polar
+predict_meas = predictMeas(new_pose, prev_lm_belief);
+
+R = [1, 0; 0, 1]; % measurement noise
+
+%% Filter Update
+G = measJacobian(prev_lm_belief, new_pose); %jacobian
+residue = p_new_obs - predict_meas;
+
+
+Q = (G' * init_sigma * G) + R; %q corrected, which is m_meas_cov in code
+
+K = init_sigma * G * (inv(Q)); %kalman gain corrected
+update_belief = prev_lm_belief + (K * (residue)); %potential transpose?
+update_sigma = (eye(2) - (K * G')) * init_sigma; %updating cov
+
+cpd = (1 / sqrt(det(2*pi*Q)))* exp(-0.5 * (residue') * inv(Q) * residue); %corrected
+
+disp('expected state estimate:');
+disp(update_belief);
+disp('expected cov matrix: ');
+disp(update_sigma);
+disp('cpd');
+disp(cpd);
+
+%% function declarations
+function G = measJacobian(lm1, new_pose1)
+    dx = lm1(1) - new_pose1(1);
+   dy = lm1(2) - new_pose1(2);
+    G = zeros(2,2);
+    if dx == 0 && dy == 0
+        G(:) = NaN;
+    else 
+        G(1,1) = dx / sqrt(dx^2 +dy^2);
+        G(1,2) = dy / sqrt(dx^2 +dy^2);
+        G(2,1) = -dy / (dx^2 +dy^2);
+        G(2,2) = dx / (dx^2 +dy^2);
+    end
+end
+
+function predict_meas = predictMeas(rob_pose, lm_pose)
+    predict_meas(1,1) = norm(rob_pose(1:2) - lm_pose, 2);
+    reco_angle = atan((lm_pose(2) - rob_pose(2))/(lm_pose(1) - rob_pose(1)));
+    if (lm_pose(1) - rob_pose(1) < 0)
+        predict_meas(2,1) = reco_angle + pi - rob_pose(3);
+        predict_meas(2,1) = predict_meas(2) - 2*pi*floor(predict_meas(2)/pi);
+    else
+        predict_meas(2,1) = reco_angle - rob_pose(3);
+    end
+end

--- a/include/EKF.h
+++ b/include/EKF.h
@@ -81,17 +81,7 @@ private:
     */
    struct Observation2D m_curr_obs;
 
-   /**
-    * @brief measurement jacobian helper function, takes the Jacobian of g(s, mu)
-    */
-   Eigen::Matrix2f measJacobian() const;
 
-   /**
-    * @brief function to calculate Kalman Filter gain for measurement correction
-    *
-    * @return A 2x2 matrix of Kalman Filter gain
-    */
-   Eigen::Matrix2f calcKalmanGain() const;
 
    /**
     * @brief calculate measurement covariance, store result in member variable
@@ -153,6 +143,21 @@ public:
     * @brief update internal copy of current robot observations
     * @details this ensures timing in constrast to the sampling approach. Must be called first every cycle
     */
-    void updateObservation(const struct Observation2D& new_obs);
+    void updateObservation(const struct Observation2D& new_obs) ;
+
+
+   /**
+   * @brief measurement jacobian helper function, takes the Jacobian of g(s, mu)
+   */
+   Eigen::Matrix2f measJacobian() const;
+
+
+      /**
+    * @brief function to calculate Kalman Filter gain for measurement correction
+    *
+    * @return A 2x2 matrix of Kalman Filter gain
+    */
+   Eigen::Matrix2f calcKalmanGain() const;
+
 
 };

--- a/src/FastSLAM/EKF_test.cpp
+++ b/src/FastSLAM/EKF_test.cpp
@@ -38,24 +38,36 @@ TEST_CASE("Empty EKF"){
 
 TEST_CASE("Non-empty EKF") {
     // set-up
-    struct Pose2D init_pose = { .x = 0, .y =0, .theta_rad = 0 };
+    struct Pose2D init_pose = { .x = 1, .y =0, .theta_rad = 0 };
     struct VelocityCommand2D init_cmd = { .vx_mps = 1, .wz_radps = 0 };
-    struct Point2D init_obs = { .x = 0, .y = 1 };
+    struct Observation2D init_obs = { .range_m = 1, .bearing_rad = M_PI/2 };
+
+    //this is 0, 1 WHICH IS CORRECT
+    Point2D init_obs_cart = {
+        init_obs.range_m * cosf(init_obs.bearing_rad),
+        init_obs.range_m * sinf(init_obs.bearing_rad),
+    };
+
     Eigen::Matrix2f init_cov;
     init_cov << 1, 0,
         0, 1;
 
+    Eigen::Matrix3f process_noise;
+    process_noise << 1.0, 0.0, 0.0,
+                     0.0, 1.0, 0.0,
+                     0.0, 0.0, 1.0;
+    
 #ifdef USE_MOCK
     std::shared_ptr<MockManager2D> test_manager =
-        std::make_shared<MockManager2D>(init_pose, init_cmd, init_cov, 0, Eigen::Matrix3f::Zero());
+        std::make_shared<MockManager2D>(init_pose, init_cmd, init_cov, 0, process_noise);
     std::shared_ptr<RobotManager2D> robot_instance(test_manager);
 #elif defined(USE_SIM)
     std::shared_ptr<RobotManager2D> robot_instance =
-        std::make_shared<Create3Manager>(init_pose, init_cmd, init_cov, 0);
+        std::make_shared<Create3Manager>(init_pose, init_cmd, init_cov, 0, process_noise);
 #endif
 
     std::unique_ptr<LMEKF2D> filled_landmark_ekf =
-        std::make_unique<LMEKF2D>(init_obs, init_cov, robot_instance);
+        std::make_unique<LMEKF2D>(init_obs_cart, init_cov, robot_instance);
 #ifdef USE_MOCK
     REQUIRE(robot_instance.use_count() == 3); // check correct ownership changes
 #endif //USE_MOCK
@@ -75,11 +87,64 @@ TEST_CASE("Non-empty EKF") {
     //TODO: needs numerical sim and mock manager
     SECTION("Test: one step updates correctly") {
 #ifdef USE_MOCK
+        //init pos, init obs, and init cmd have alr been given
+        //lm in world view - correct
+        struct Point2D world_obs = test_manager->inverseMeas(init_pose, init_obs);
+        //init cmd for vel - give it the command
+        test_manager->sampleControl();
         test_manager->sampleIMU();
-#endif //USE_MOCK
+        //returns new pose of robot after the control - correct
+        struct Pose2D new_pose = test_manager->motionUpdate();
+
+        // new obs - this is not working, and instead returns 0,0 ?
+        test_manager->sampleLandMark();
+        struct Observation2D new_obs = test_manager->getCurrObs();
+        std::cout << "New observation: range =" << new_obs.range_m << ", bearing =" << new_obs.bearing_rad << std::endl;
+        
+        //update ekf
+        filled_landmark_ekf->updateObservation(new_obs);
+
+        struct Observation2D predicted = test_manager->predictMeas(world_obs);
+        
+        
+        //i made measJacobian and calcKalman public in ekf.h for debugging
+        //testing jacobian
+        //auto res = filled_landmark_ekf->measJacobian();
+        //std::cout << "jacobian" << res << std::endl;
+        filled_landmark_ekf->update();
+
+       
+        //testing kalman
+        //auto kal = filled_landmark_ekf->calcKalmanGain();
+        //std::cout << "kalman" << kal<<  std::endl;
+
+        //testing predict meas
+        std::cout << "predict: " << predicted.range_m << ", " << predicted.bearing_rad << std::endl;
+        
+        
+        Eigen::Vector2f expected_state(-0.1312, 1.3999);
+        Eigen::Matrix2f expected_cov;
+        expected_cov << 0.5000f, 0.f,
+                        0.f, 0.6667f;
+        struct Point2D actual_res = filled_landmark_ekf->getLMEst();
+        std::cout << "estimate: " << actual_res.x << ", " << actual_res.y << std::endl;
+        //Eigen::Matrix2f actual_cov = filled_landmark_ekf->getCovariance();
+
+        REQUIRE_THAT(expected_state(0), Catch::Matchers::WithinRel(actual_res.x, 0.01f) ||
+                                        Catch::Matchers::WithinAbs(actual_res.x, 0.01f));
+        REQUIRE_THAT(expected_state(1), Catch::Matchers::WithinRel(actual_res.y, 0.01f) ||
+                                        Catch::Matchers::WithinAbs(actual_res.y, 0.01f));
+        //i initially had a getCovariance() and then got rid of it
+        //REQUIRE((filled_landmark_ekf->getCovariance().isApprox(expected_cov, 0.01)));
     }
+#endif //USE_MOCK
 
     SECTION("Test: calculation of correct observation correspondence") {
-        //TODO: requires mock-up robot manager
+#ifdef USE_MOCK
+        
+        float cpd = filled_landmark_ekf->calcCPD();
+        float expected_cpd = 0.0711f;
+        REQUIRE_THAT(cpd, Catch::Matchers::WithinRel(expected_cpd, 0.01f));
+#endif // USE_MOCK
     }
 }

--- a/src/FastSLAM/EKF_test.cpp
+++ b/src/FastSLAM/EKF_test.cpp
@@ -38,25 +38,14 @@ TEST_CASE("Empty EKF"){
 
 TEST_CASE("Non-empty EKF") {
     // set-up
-    struct Pose2D init_pose = { .x = 1, .y =0, .theta_rad = 0 };
+    struct Pose2D init_pose = { .x = 0, .y =0, .theta_rad = 0 };
     struct VelocityCommand2D init_cmd = { .vx_mps = 1, .wz_radps = 0 };
     struct Observation2D init_obs = { .range_m = 1, .bearing_rad = M_PI/2 };
+    struct Point2D init_belief = {.x = 0.0f, .y = 1.0f};
+    Eigen::Matrix2f init_cov = Eigen::Matrix2f::Identity();
 
-    //this is 0, 1 WHICH IS CORRECT
-    Point2D init_obs_cart = {
-        init_obs.range_m * cosf(init_obs.bearing_rad),
-        init_obs.range_m * sinf(init_obs.bearing_rad),
-    };
+    Eigen::Matrix3f process_noise = Eigen::Matrix3f::Identity();
 
-    Eigen::Matrix2f init_cov;
-    init_cov << 1, 0,
-        0, 1;
-
-    Eigen::Matrix3f process_noise;
-    process_noise << 1.0, 0.0, 0.0,
-                     0.0, 1.0, 0.0,
-                     0.0, 0.0, 1.0;
-    
 #ifdef USE_MOCK
     std::shared_ptr<MockManager2D> test_manager =
         std::make_shared<MockManager2D>(init_pose, init_cmd, init_cov, 0, process_noise);
@@ -67,7 +56,8 @@ TEST_CASE("Non-empty EKF") {
 #endif
 
     std::unique_ptr<LMEKF2D> filled_landmark_ekf =
-        std::make_unique<LMEKF2D>(init_obs_cart, init_cov, robot_instance);
+        std::make_unique<LMEKF2D>(init_belief, init_cov, robot_instance);
+
 #ifdef USE_MOCK
     REQUIRE(robot_instance.use_count() == 3); // check correct ownership changes
 #endif //USE_MOCK
@@ -84,67 +74,33 @@ TEST_CASE("Non-empty EKF") {
 
     }
 
-    //TODO: needs numerical sim and mock manager
     SECTION("Test: one step updates correctly") {
 #ifdef USE_MOCK
-        //init pos, init obs, and init cmd have alr been given
-        //lm in world view - correct
-        struct Point2D world_obs = test_manager->inverseMeas(init_pose, init_obs);
-        //init cmd for vel - give it the command
-        test_manager->sampleControl();
-        test_manager->sampleIMU();
-        //returns new pose of robot after the control - correct
         struct Pose2D new_pose = test_manager->motionUpdate();
+        struct Observation2D new_obs = {.range_m = 1.5f, .bearing_rad = M_PI_4f};
+        test_manager->setObs(new_obs);
 
-        // new obs - this is not working, and instead returns 0,0 ?
-        test_manager->sampleLandMark();
-        struct Observation2D new_obs = test_manager->getCurrObs();
-        std::cout << "New observation: range =" << new_obs.range_m << ", bearing =" << new_obs.bearing_rad << std::endl;
-        
         //update ekf
-        filled_landmark_ekf->updateObservation(new_obs);
+        filled_landmark_ekf->updateObservation(test_manager->getCurrObs());
 
-        struct Observation2D predicted = test_manager->predictMeas(world_obs);
-        
-        
-        //i made measJacobian and calcKalman public in ekf.h for debugging
-        //testing jacobian
-        //auto res = filled_landmark_ekf->measJacobian();
-        //std::cout << "jacobian" << res << std::endl;
+        // check CPD before updating EKF
+        float cpd = filled_landmark_ekf->calcCPD();
+        float expected_cpd = 0.0452f;
+        REQUIRE_THAT(cpd, Catch::Matchers::WithinRel(expected_cpd, 0.01f));
+
         filled_landmark_ekf->update();
 
-       
-        //testing kalman
-        //auto kal = filled_landmark_ekf->calcKalmanGain();
-        //std::cout << "kalman" << kal<<  std::endl;
-
-        //testing predict meas
-        std::cout << "predict: " << predicted.range_m << ", " << predicted.bearing_rad << std::endl;
-        
-        
-        Eigen::Vector2f expected_state(-0.1312, 1.3999);
+        Eigen::Vector2f expected_state(-0.5857f, 1.4950f);
         Eigen::Matrix2f expected_cov;
         expected_cov << 0.5000f, 0.f,
                         0.f, 0.6667f;
         struct Point2D actual_res = filled_landmark_ekf->getLMEst();
-        std::cout << "estimate: " << actual_res.x << ", " << actual_res.y << std::endl;
-        //Eigen::Matrix2f actual_cov = filled_landmark_ekf->getCovariance();
 
         REQUIRE_THAT(expected_state(0), Catch::Matchers::WithinRel(actual_res.x, 0.01f) ||
                                         Catch::Matchers::WithinAbs(actual_res.x, 0.01f));
         REQUIRE_THAT(expected_state(1), Catch::Matchers::WithinRel(actual_res.y, 0.01f) ||
                                         Catch::Matchers::WithinAbs(actual_res.y, 0.01f));
-        //i initially had a getCovariance() and then got rid of it
-        //REQUIRE((filled_landmark_ekf->getCovariance().isApprox(expected_cov, 0.01)));
-    }
 #endif //USE_MOCK
-
-    SECTION("Test: calculation of correct observation correspondence") {
-#ifdef USE_MOCK
-        
-        float cpd = filled_landmark_ekf->calcCPD();
-        float expected_cpd = 0.0711f;
-        REQUIRE_THAT(cpd, Catch::Matchers::WithinRel(expected_cpd, 0.01f));
-#endif // USE_MOCK
     }
+
 }


### PR DESCRIPTION
Changes:
- Add `ekf_verify.m` script. This is a matlab script that simulates one-step ekf update with arbitrary inputs. Use this script to verify
- Add various fixes to `EKF.cpp`. Note that `this->calcMeasCov()` on line 54 was missing, since `this->calcCPD()` updates `m_meas_cov`, and it was assumed by the algorithm that `calcCPD()` will be run before `update()`. This is potentially dangerous and should be investigated in the future. For now `calcMeasCov()` is called by `update()` and it does not impact KF correction.
- Add `EKF_test.cpp`, containing various unit tests for the `LMEKF2D` class. More test should be added in the future to test error handling capabilities of this class and its interfaces.