### PR TITLE
JGALP-134: Finds the coordinates of LMs associated with a particle

### DIFF
--- a/include/particle-filter.h
+++ b/include/particle-filter.h
@@ -208,7 +208,7 @@ public:
      * @param[in] cdf_vec: cdf vector containing cumulative sum of all weights
      * @param[in] sample: randomly-generated number in range of the cdf table
      */
-    int drawWithReplacement(const std::vector<float>& cdf_vec, float sample);
+    int drawWithReplacement(const std::vector<float>& cdf_vec, float sample)const;
 
      /**
      * @brief samples one particle, based on weights, and estimates the landmarks of each EKF

--- a/include/particle-filter.h
+++ b/include/particle-filter.h
@@ -8,6 +8,7 @@
 #include "EKF.h"
 #include <unordered_map>
 #include <queue>
+#include <vector>
 
 enum class PF_RET{ SUCCESS = 0, EMPTY_ROBOT_MANAGER = -1, MATRIX_INVERSION_ERROR = -2, UPDATE_ERROR = -3 };
 constexpr unsigned int DEFAULT_NUM_PARTICLE = 50;
@@ -212,7 +213,7 @@ public:
      /**
      * @brief samples one particle, based on weights, and estimates the landmarks of each EKF
      * assosciated with the particle
-     * @return queue of 2DPoints, corresponding to the landmarks associated with that particle
+     * @return vector of 2DPoints, corresponding to the landmarks associated with that particle
      */
-    std::queue<struct Point2D> sampleLandmarks();
+    std::vector<struct Point2D> sampleLandmarks();
 };

--- a/include/particle-filter.h
+++ b/include/particle-filter.h
@@ -114,7 +114,7 @@ public:
      * @brief finds the coordinates of all the landmarks assosciated with a particle
      * @return queue of all the landmark coordinates 
      */
-    std::queue<struct Point2D> getLandmarkCoordinates();
+    const std::vector<struct Point2D> getLandmarkCoordinates() const;
 };
 
 class FastSLAMPF {
@@ -215,5 +215,5 @@ public:
      * assosciated with the particle
      * @return vector of 2DPoints, corresponding to the landmarks associated with that particle
      */
-    std::vector<struct Point2D> sampleLandmarks();
+    const std::vector<struct Point2D> sampleLandmarks() const;
 };

--- a/include/particle-filter.h
+++ b/include/particle-filter.h
@@ -108,6 +108,12 @@ public:
      */
     float updateParticle(const struct Observation2D& new_obs,
                          const struct Pose2D& new_pose);
+
+     /**
+     * @brief finds the coordinates of all the landmarks assosciated with a particle
+     * @return queue of all the landmark coordinates 
+     */
+    std::queue<struct Point2D> getLandmarkCoordinates();
 };
 
 class FastSLAMPF {
@@ -202,4 +208,11 @@ public:
      * @param[in] sample: randomly-generated number in range of the cdf table
      */
     int drawWithReplacement(const std::vector<float>& cdf_vec, float sample);
+
+     /**
+     * @brief samples one particle, based on weights, and estimates the landmarks of each EKF
+     * assosciated with the particle
+     * @return queue of 2DPoints, corresponding to the landmarks associated with that particle
+     */
+    std::queue<struct Point2D> sampleLandmarks();
 };

--- a/src/FastSLAM/particle-filter.cpp
+++ b/src/FastSLAM/particle-filter.cpp
@@ -49,7 +49,7 @@ struct Pose2D FastSLAMPF::samplePose(const struct Pose2D& a_pose_mean) {
     return ret;
 }
 
-int FastSLAMPF::drawWithReplacement(const std::vector<float>& cdf_vec, float sample){
+int FastSLAMPF::drawWithReplacement(const std::vector<float>& cdf_vec, float sample) const{
     int start = 0;
     int end = cdf_vec.size()-1;
     if (sample < 0 || sample > cdf_vec[end]) return -1;
@@ -103,10 +103,10 @@ void FastSLAMPF::updateFilter(const struct Pose2D &a_robot_pose_mean,
     reSampleParticles();
 }
 
-const std::vector<struct Point2D> FastSLAMPF::sampleLandmarks() const{
+const std::vector<struct Point2D> FastSLAMPF::sampleLandmarks() const {
     std::vector<float> cdf_table;
     float total_weight = MathUtil::genCDF(m_particle_weights, cdf_table);
     float sampled_weight = MathUtil::sampleUniform(0.0, total_weight);
-    int sampled_idx = drawWithReplacement(cdf_table, sampled_weight);
-    return m_particle_set[sampled_idx]->getLandmarkCoordinates();  
+    int sampled_idx = drawWithReplacement(cdf_table, sampled_weight); 
+    return (m_particle_set.at(sampled_idx))->getLandmarkCoordinates();  
 }

--- a/src/FastSLAM/particle-filter.cpp
+++ b/src/FastSLAM/particle-filter.cpp
@@ -103,7 +103,7 @@ void FastSLAMPF::updateFilter(const struct Pose2D &a_robot_pose_mean,
     reSampleParticles();
 }
 
-std::queue<struct Point2D> FastSLAMPF::sampleLandmarks(){
+std::vector<struct Point2D> FastSLAMPF::sampleLandmarks(){
     std::vector<float> cdf_table;
     float total_weight = MathUtil::genCDF(m_particle_weights, cdf_table);
     float sampled_weight = MathUtil::sampleUniform(0.0, total_weight);

--- a/src/FastSLAM/particle-filter.cpp
+++ b/src/FastSLAM/particle-filter.cpp
@@ -103,7 +103,7 @@ void FastSLAMPF::updateFilter(const struct Pose2D &a_robot_pose_mean,
     reSampleParticles();
 }
 
-std::vector<struct Point2D> FastSLAMPF::sampleLandmarks(){
+const std::vector<struct Point2D> FastSLAMPF::sampleLandmarks() const{
     std::vector<float> cdf_table;
     float total_weight = MathUtil::genCDF(m_particle_weights, cdf_table);
     float sampled_weight = MathUtil::sampleUniform(0.0, total_weight);

--- a/src/FastSLAM/particle-filter.cpp
+++ b/src/FastSLAM/particle-filter.cpp
@@ -102,3 +102,13 @@ void FastSLAMPF::updateFilter(const struct Pose2D &a_robot_pose_mean,
     }
     reSampleParticles();
 }
+
+std::queue<struct Point2D> FastSLAMPF::sampleLandmarks(){
+    std::vector<float> cdf_table;
+    float total_weight = MathUtil::genCDF(m_particle_weights, cdf_table);
+    float sampled_weight = MathUtil::sampleUniform(0.0, total_weight);
+    int sampled_idx = drawWithReplacement(cdf_table, sampled_weight);
+    std::unique_ptr<FastSLAMParticles> particle_drew =
+            std::make_unique<FastSLAMParticles>(*m_particle_set[sampled_idx]);
+    return particle_drew->getLandmarkCoordinates();  
+}

--- a/src/FastSLAM/particle-filter.cpp
+++ b/src/FastSLAM/particle-filter.cpp
@@ -108,7 +108,5 @@ const std::vector<struct Point2D> FastSLAMPF::sampleLandmarks() const{
     float total_weight = MathUtil::genCDF(m_particle_weights, cdf_table);
     float sampled_weight = MathUtil::sampleUniform(0.0, total_weight);
     int sampled_idx = drawWithReplacement(cdf_table, sampled_weight);
-    std::unique_ptr<FastSLAMParticles> particle_drew =
-            std::make_unique<FastSLAMParticles>(*m_particle_set[sampled_idx]);
-    return particle_drew->getLandmarkCoordinates();  
+    return m_particle_set[sampled_idx]->getLandmarkCoordinates();  
 }

--- a/src/FastSLAM/particles.cpp
+++ b/src/FastSLAM/particles.cpp
@@ -121,9 +121,9 @@ float FastSLAMParticles::updateParticle(const struct Observation2D& new_obs,
         static_cast<float>(PF_RET::UPDATE_ERROR);
 }
 
-std::vector<struct Point2D> FastSLAMParticles::getLandmarkCoordinates(){
+const std::vector<struct Point2D> FastSLAMParticles::getLandmarkCoordinates() const{
     std::vector<struct Point2D> landmarks;
-    for(auto ekf : m_lmekf_bank){
+    for(const auto& ekf : m_lmekf_bank){
         landmarks.push_back(ekf.first->getLMEst());
     }
     return landmarks;

--- a/src/FastSLAM/particles.cpp
+++ b/src/FastSLAM/particles.cpp
@@ -120,3 +120,11 @@ float FastSLAMParticles::updateParticle(const struct Observation2D& new_obs,
         m_lmekf_bank[m_data_label].first->calcCPD() :
         static_cast<float>(PF_RET::UPDATE_ERROR);
 }
+
+std::queue<struct Point2D> FastSLAMParticles::getLandmarkCoordinates(){
+    std::queue<struct Point2D> landmarks;
+    for(int i = 0; i<this->getNumLandMark(); i++){
+        landmarks.push(m_lmekf_bank[i].first->getLMEst());
+    }
+    return landmarks;
+}

--- a/src/FastSLAM/particles.cpp
+++ b/src/FastSLAM/particles.cpp
@@ -121,10 +121,10 @@ float FastSLAMParticles::updateParticle(const struct Observation2D& new_obs,
         static_cast<float>(PF_RET::UPDATE_ERROR);
 }
 
-std::queue<struct Point2D> FastSLAMParticles::getLandmarkCoordinates(){
-    std::queue<struct Point2D> landmarks;
-    for(int i = 0; i<this->getNumLandMark(); i++){
-        landmarks.push(m_lmekf_bank[i].first->getLMEst());
+std::vector<struct Point2D> FastSLAMParticles::getLandmarkCoordinates(){
+    std::vector<struct Point2D> landmarks;
+    for(auto ekf : m_lmekf_bank){
+        landmarks.push_back(ekf.first->getLMEst());
     }
     return landmarks;
 }


### PR DESCRIPTION
-getLandmarkCoordinates() in FastSLAMParticles calls getLMEst on each ekf in m_lmekf_bank
	-adds all the coordinates to a Point2D queue
-sampleLandmarks() in FastSLAMPF samples one particle, based on weights and calls
 getLandmarkCoordinates() on that particle